### PR TITLE
Rename raw view in README.md from "an_json_view"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ def an_ordinary_view(request):
 
 
 @view(render_to='json')
-def an_json_view(request):
+def a_json_view(request):
     return {'stuff': stuff}
 
+
 @view(render_to='raw')
-def an_json_view(request):
+def a_raw_view(request):
     return 'hey'
 ```
 
@@ -274,4 +275,4 @@ There are other utility functions, but I didn't take the time to document them h
 
 BTW, it's under the [zlib licence](http://www.zlib.net/zlib_license.html).
 
-It embed [namegen](https://github.com/amnong/namegen), a name generator under BSD licence.
+It embeds [namegen](https://github.com/amnong/namegen), a name generator under BSD licence.


### PR DESCRIPTION
Example raw view function was called "an_json_view". Rename to "a_raw_view".
