### PR TITLE
Python3 and Django 1.7 support

### DIFF
--- a/django_quicky/__init__.py
+++ b/django_quicky/__init__.py
@@ -5,7 +5,7 @@
 
 VERSION = __version__ = "0.6.4"
 
-from decorators import view, routing
-from utils import setting, load_config
-from models import get_object_or_none
+from .decorators import view, routing
+from .utils import setting, load_config
+from .models import get_object_or_none
 

--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -12,7 +12,7 @@ from django.http import HttpResponse
 from django.conf.urls import include, url as addurl
 from django.shortcuts import render
 
-from utils import HttpResponseException
+from .utils import HttpResponseException
 
 
 __all__ = ["view", "routing"]

--- a/django_quicky/decorators.py
+++ b/django_quicky/decorators.py
@@ -123,9 +123,14 @@ def view(render_to=None, *args, **kwargs):
                 if rendering and not isinstance(response, HttpResponse):
 
                     if rendering == 'json':
-                        return HttpResponse(json.dumps(response),
-                                            mimetype="application/json",
-                                            *decorator_args, **decorator_kwargs)
+                        if django.VERSION[0] >= 1 and django.VERSION[1] >= 7:
+                            return HttpResponse(json.dumps(response),
+                                                content_type="application/json",
+                                                *decorator_args, **decorator_kwargs)
+                        else:
+                            return HttpResponse(json.dumps(response),
+                                                mimetype="application/json",
+                                                *decorator_args, **decorator_kwargs)
                     if rendering == 'raw':
                         return HttpResponse(response,
                                             *decorator_args, **decorator_kwargs)

--- a/django_quicky/management/commands/clear_sessions.py
+++ b/django_quicky/management/commands/clear_sessions.py
@@ -35,4 +35,4 @@ class Command(BaseCommand):
                 return
 
         Session.objects.all().delete()
-        print '%s sessions deleted' % total
+        print('%s sessions deleted' % total)

--- a/django_quicky/middleware.py
+++ b/django_quicky/middleware.py
@@ -12,9 +12,9 @@ from django.shortcuts import redirect, render
 
 from django.contrib.auth.models import User
 
-from namegen.namegen import NameGenerator
+from .namegen.namegen import NameGenerator
 
-from utils import setting
+from .utils import setting
 
 
 class ForceSuperUserMiddleWare(object):


### PR DESCRIPTION
Changed a few imports to make the explicitly relative for python3. 

Changed a print statement in the clear_sessions command to support python3. 

Updated the logic for returning json responses to work with django 1.7. 

